### PR TITLE
Apply a few fixes in build-go.yml

### DIFF
--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -21,7 +21,7 @@ on:
     outputs:
       new-version:
         description: "The new service version"
-        value: ${{ jobs.build.outputs.service-version }}
+        value: ${{ jobs.generate-version.outputs.service-version }}
 
 env:
    HOME: ${{github.workspace}}


### PR DESCRIPTION
- Fix the issue when it was not possible to download swagger outside of go module
- Fix the issue when the build-go pipeline didn't produce the output version