### PR TITLE
Implement the build-frontend-npm pipeline

### DIFF
--- a/.github/workflows/build-frontend-npm.yml
+++ b/.github/workflows/build-frontend-npm.yml
@@ -39,11 +39,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
-      - name: Install yarn dependencies
+          cache: 'npm'
+      - name: Install dependencies
         run: npm ci --legacy-peer-deps
       - name: Run build
         run: npm run build
-      - name: Install yarn production dependencies
+      - name: Install production dependencies
         run: npm ci --omit=dev --legacy-peer-deps
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
Client-site is incompatible with Yarn and it is not straightforward to migrate the service. The pipeline builds a service using NPM