### PR TITLE
feat: set global GITHUB_TOKEN

### DIFF
--- a/.github/workflows/build-frontend-library.yml
+++ b/.github/workflows/build-frontend-library.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   HOME: ${{github.workspace}}
+  GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
 jobs:
   build:
@@ -29,25 +30,23 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
       # Install yarn as we are using a self-hosted runner
       - name: Install Yarn
         run: |
           npm install -g yarn@1.22.22
       - name: Install yarn dependencies
         run: yarn install --frozen-lockfile
-#      - name: Run lint
-#        run: yarn run lint
+      #- name: Run lint
+      #  run: yarn run lint
       - name: Run build
         run: yarn build
       - name: Publish package
         if: ${{inputs.publish}}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name github-actions
           git config user.email github-actions[bot]@users.noreply.github.com
-          echo "//npm.pkg.github.com/:_authToken=${{ env.NODE_AUTH_TOKEN }}" > ~/.npmrc
+          echo "//npm.pkg.github.com/:_authToken=${{ env.GITHUB_TOKEN }}" > ~/.npmrc
           yarn version --minor
           yarn publish
           git push origin --follow-tags


### PR DESCRIPTION
Some projects could use GITHUB_TOKEN to pull private dependencies, so we need to have it in the build jobs globally, not only for publish