### PR TITLE
feat: Switch secrets to vars

### DIFF
--- a/.github/workflows/build-frontend-package.yml
+++ b/.github/workflows/build-frontend-package.yml
@@ -49,7 +49,7 @@ jobs:
           node-version-file: ".nvmrc"
       - name: Prepare .env.local file
         run: |
-          echo "${{ secrets[matrix.combo.env_local] }}" > .env.local
+          echo "${{ vars[matrix.combo.env_local] }}" > .env.local
       - name: Install Yarn
         run: |
           npm install -g yarn@1.22.22


### PR DESCRIPTION
The env.local file does not contain secrets, so we can change secrets to vars. Also secrets are hard to manage, because you can't check the current values, only when creating