### PR TITLE
Optimize the build-go pipeline

### DIFF
--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: '${{ inputs.app_dir }}/go.mod'
-          cache-dependency-path: '${{ inputs.app_dir }}/go.sum'
+          cache: false
       - name: Set up gotestfmt
         uses: GoTestTools/gotestfmt-action@v2
         with:


### PR DESCRIPTION
- Merge a version generation and publish into the build job.
- Disable Golang cache as it doesn't make sense. It fact, it works slightly faster without cache. Read more https://github.com/orgs/community/discussions/18549
- Enable Docker cache